### PR TITLE
perf: read counters with RDPMC when possible on amd64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/aclements/go-perfevent
 
-go 1.21
+go 1.22
 
-require golang.org/x/sys v0.17.0
+require golang.org/x/sys v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/perf/counter_test.go
+++ b/perf/counter_test.go
@@ -112,3 +112,20 @@ func checkCount(t *testing.T, count Count, min Count) {
 		t.Fatal("TimeRunning decreased")
 	}
 }
+
+func BenchmarkReadOne(b *testing.B) {
+	c, err := OpenCounter(TargetThisGoroutine, events.EventCPUCycles)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer c.Close()
+
+	c.Start()
+
+	for range b.N {
+		_, err := c.ReadOne()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/perf/rdpmc_amd64.go
+++ b/perf/rdpmc_amd64.go
@@ -1,0 +1,7 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package perf
+
+func rdpmc(counter uint32) int64

--- a/perf/rdpmc_amd64.s
+++ b/perf/rdpmc_amd64.s
@@ -1,0 +1,19 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// func rdpmc(counter uint32) int64
+TEXT ·rdpmc(SB), NOSPLIT, $8-8
+	// RDPMC is not a serializing instruction and thus may run out of order
+	// w.r.t. the events we want to count. Add explicit serialization.
+	MOVL	$0, AX
+	CPUID
+
+	MOVL	counter+0(FP), CX
+	RDPMC
+	MOVL	AX, ret_lo+8(FP)
+	MOVL	DX, ret_hi+12(FP)
+
+	RET

--- a/perf/rdpmc_other.go
+++ b/perf/rdpmc_other.go
@@ -1,0 +1,11 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !amd64
+
+package perf
+
+func rdpmc(counter uint32) int64 {
+	panic("unreachable")
+}


### PR DESCRIPTION
My primary motivation with this change is to reduce overhead of ReadOne to make it feasible to measure counters in small regions. e.g., I would like ignore cache misses in a routine explicitly intended to flush the cache.

Using RDPMC with the perf_event_open API is fairly straightforward. The primary annoyance is that the ability to use RDPMC can disappear arbitrarily at run time. Multiplexing of many events is an obvious case of this. That said, I saw this changing on my machine even when there were no other PMU users that I am aware of, so it seems there are other cases as well.

I've bumped the Go version to 1.22 for range-over-int.

```
goos: linux
goarch: amd64
pkg: github.com/aclements/go-perfevent/perf
cpu: Intel(R) Xeon(R) W-2135 CPU @ 3.70GHz
           │ /tmp/before.txt │            /tmp/after.txt            │
           │     sec/op      │    sec/op     vs base                │
ReadOne-12    1347.00n ± 15%   80.21n ± 50%  -94.05% (p=0.000 n=10)
```

(It is ~25ns/op without a serializing instruction. It would be interesting to know if we could elide that in favor of something cheaper like MFENCE depending on the event.)